### PR TITLE
Add CRD for 3scale application

### DIFF
--- a/grpc/threescale/app-grpc.yaml
+++ b/grpc/threescale/app-grpc.yaml
@@ -1,0 +1,14 @@
+kind: Application
+apiVersion: capabilities.3scale.net/v1beta1
+metadata:
+  name: application-grpc
+spec:
+  accountCR:
+    name: developeraccount01
+  applicationPlanName: plan_basic
+  description: 'GRPC application'
+  name: grpc-app
+  productCR:
+    name: grpc-helloworld
+  suspend: false
+


### PR DESCRIPTION
Since version 2.13 3scale operator supports creation of Applicationa via CRD. 